### PR TITLE
fix: fix account info in cdk context and add removal policy to constructs

### DIFF
--- a/examples/spark-data-lake/infra/cdk.context.json
+++ b/examples/spark-data-lake/infra/cdk.context.json
@@ -1,10 +1,10 @@
 {
     "staging": {
-      "accountId": "ACCOUNT-ID",
+      "account": "ACCOUNT-ID",
       "region": "REGION"
     },
     "prod": {
-      "accountId": "ACCOUNT-ID",
+      "account": "ACCOUNT-ID",
       "region": "REGION"
     },
     "@aws-data-solutions-framework/removeDataOnDestroy": true

--- a/examples/spark-data-lake/infra/stacks/application_stack.py
+++ b/examples/spark-data-lake/infra/stacks/application_stack.py
@@ -79,7 +79,8 @@ class ApplicationStack(Stack):
 
         # Use AWS DSF to create Spark EMR serverless runtime, package Spark app, and create a Spark job.
         spark_runtime = dsf.SparkEmrServerlessRuntime(
-            self, "SparkProcessingRuntime", name="TaxiAggregation"
+            self, "SparkProcessingRuntime", name="TaxiAggregation",
+            removal_policy=RemovalPolicy.DESTROY,
         )
         spark_app = dsf.PySparkApplicationPackage(
             self,


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Fix the account information syntax in the example for cross account deployments.

Add removal policy to constructs part of the Application Stack 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
