### PR TITLE
fix: sparkSparkEmrServerlessJob doesn’t provide the removal_policy parameter

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -6319,6 +6319,8 @@ const sparkEmrServerlessJobProps: SparkEmrServerlessJobProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | The removal policy when deleting the CDK resource. |
+| <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.schedule">schedule</a></code> | <code>aws-cdk-lib.aws_events.Schedule</code> | Schedule to run the Step Functions state machine. |
 | <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.applicationId">applicationId</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.name">name</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.sparkSubmitEntryPoint">sparkSubmitEntryPoint</a></code> | <code>string</code> | *No description.* |
@@ -6336,6 +6338,38 @@ const sparkEmrServerlessJobProps: SparkEmrServerlessJobProps = { ... }
 | <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.sparkSubmitEntryPointArguments">sparkSubmitEntryPointArguments</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.sparkSubmitParameters">sparkSubmitParameters</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#aws-dsf.SparkEmrServerlessJobProps.property.tags">tags</a></code> | <code>{[ key: string ]: any}</code> | *No description.* |
+
+---
+
+##### `removalPolicy`<sup>Optional</sup> <a name="removalPolicy" id="aws-dsf.SparkEmrServerlessJobProps.property.removalPolicy"></a>
+
+```typescript
+public readonly removalPolicy: RemovalPolicy;
+```
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+- *Default:* The resources are not deleted (`RemovalPolicy.RETAIN`).
+
+The removal policy when deleting the CDK resource.
+
+If DESTROY is selected, context value `@aws-data-solutions-framework/removeDataOnDestroy` needs to be set to true.
+Otherwise the removalPolicy is reverted to RETAIN.
+
+---
+
+##### `schedule`<sup>Optional</sup> <a name="schedule" id="aws-dsf.SparkEmrServerlessJobProps.property.schedule"></a>
+
+```typescript
+public readonly schedule: Schedule;
+```
+
+- *Type:* aws-cdk-lib.aws_events.Schedule
+
+Schedule to run the Step Functions state machine.
+
+> [Schedule](Schedule)
+
+> [[https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.Schedule.html]]([https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_events.Schedule.html])
 
 ---
 

--- a/framework/src/processing/spark-job/spark-job-emr-serverless.ts
+++ b/framework/src/processing/spark-job/spark-job-emr-serverless.ts
@@ -224,6 +224,8 @@ export class SparkEmrServerlessJob extends SparkJob {
           SparkSubmit: {},
         },
       },
+      removalPolicy: props.removalPolicy,
+      schedule: props.schedule,
     } as SparkEmrServerlessJobApiProps;
 
     config.jobConfig.Name = props.name;
@@ -297,7 +299,7 @@ export class SparkEmrServerlessJob extends SparkJob {
  * @param tags Tags to be added to the EMR Serverless job. @see @link[https://docs.aws.amazon.com/emr-serverless/latest/APIReference/API_StartJobRun.html]
  */
 
-export interface SparkEmrServerlessJobProps {
+export interface SparkEmrServerlessJobProps extends SparkJobProps {
   readonly name: string;
   readonly applicationId: string;
   readonly executionRoleArn?: string;

--- a/framework/test/e2e/spark-job.e2e.test.ts
+++ b/framework/test/e2e/spark-job.e2e.test.ts
@@ -61,6 +61,7 @@ const job = new SparkEmrServerlessJob(stack, 'SparkJob', {
       },
     },
   },
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
 } as SparkEmrServerlessJobApiProps);
 
 

--- a/framework/test/e2e/spark-job.e2e.test.ts
+++ b/framework/test/e2e/spark-job.e2e.test.ts
@@ -25,6 +25,8 @@ const emrApp = new SparkEmrServerlessRuntime(stack, 'emrApp', {
   name: 'my-test-app',
 });
 
+stack.node.setContext('@aws-data-solutions-framework/removeDataOnDestroy', true);
+
 const myFileSystemPolicy = new PolicyDocument({
   statements: [new PolicyStatement({
     actions: [

--- a/framework/test/unit/processing/spark-job.test.ts
+++ b/framework/test/unit/processing/spark-job.test.ts
@@ -121,10 +121,17 @@ describe('Create an SparkJob using EMR Serverless Application for Spark using si
     cloudWatchLogGroupName: 'spark-serverless-log',
     sparkSubmitEntryPoint: 's3://s3-bucket/pi.py',
     sparkSubmitParameters: '--conf spark.executor.instances=2 --conf spark.executor.memory=2G --conf spark.driver.memory=2G --conf spark.executor.cores=4',
+    schedule: Schedule.rate(Duration.hours(1)),
   } as SparkEmrServerlessJobProps);
 
 
   const template = Template.fromStack(stack, {});
+
+  test('Schedule is created', () => {
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'rate(1 hour)',
+    });
+  });
 
   test('State function is created EMR Serverless', () => {
     template.resourceCountIs('AWS::StepFunctions::StateMachine', 1);


### PR DESCRIPTION
## Description of changes:

Added removalPolicy property to sparkSparkEmrServerlessJob
Updated unit tests.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)
