### PR TITLE
fix: improve tracked construct

### DIFF
--- a/framework/src/utils/tracked-construct.ts
+++ b/framework/src/utils/tracked-construct.ts
@@ -33,7 +33,7 @@ export class TrackedConstruct extends Construct {
   /**
    * Format is "Description (uksb_12345abcde) (version:1.2.3) (tag:construct1,construct2)"
    */
-  private static readonly trackingRegExp = new RegExp('(.+) \\(' + TrackedConstruct.ADSF_TRACKING_CODE + '\\)( \\(version:(.+)\\))? \\(tag:(.+)\\)');
+  private static readonly trackingRegExp = new RegExp('(.+) \\(' + TrackedConstruct.ADSF_TRACKING_CODE + '\\)( \\(version:([^)]*)\\))?( \\(tag:([^)]*)\\))?');
   private static readonly TRACKING_TAG_SEPARATOR = ',';
 
   /**
@@ -57,14 +57,29 @@ export class TrackedConstruct extends Construct {
 
   private updateDescription(currentDescription: string, props: TrackedConstructProps) {
     const fullDescription = TrackedConstruct.trackingRegExp.exec(currentDescription);
+
     const version = this.retrieveVersion();
 
     const tag = props.trackingTag.split(TrackedConstruct.TRACKING_TAG_SEPARATOR).join('_'); // make sure there's no separator in the tag name
     if (fullDescription == null) {
       return `${currentDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${version}) (tag:${tag})`;
     } else {
-      let tags = fullDescription[4] + TrackedConstruct.TRACKING_TAG_SEPARATOR + tag;
-      return `${fullDescription[1]} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${fullDescription[3]}) (tag:${tags})`;
+      const description = fullDescription[1];
+      const existingTags = fullDescription[5];
+
+      let newTags;
+      if (existingTags) {
+        const tags = existingTags.split(TrackedConstruct.TRACKING_TAG_SEPARATOR);
+        if (tags.includes(tag)) {
+          newTags = existingTags;
+        } else {
+          newTags = existingTags + TrackedConstruct.TRACKING_TAG_SEPARATOR + tag;
+        }
+      } else {
+        newTags = tag;
+      }
+
+      return `${description} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${version}) (tag:${newTags})`;
     }
   }
 

--- a/framework/test/unit/utils/tracked-construct.test.ts
+++ b/framework/test/unit/utils/tracked-construct.test.ts
@@ -14,115 +14,190 @@ import { Construct } from 'constructs';
 import { ADSF_AWS_TAG } from '../../../src/constants';
 import { ContextOptions, TrackedConstruct, TrackedConstructProps } from '../../../src/utils';
 
-test('tracked construct add tracking code and tag to description if not explicitly disabled', () => {
-  // GIVEN
-  const initialStackDescription = 'My Analytics stack';
-  const trackingTag = 'trackingTag';
+describe('TrackedConstruct tests', ()=> {
 
-  const testApp = new App();
-  const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
-    description: initialStackDescription,
+  test('tracked construct add tracking code and tag to description if not explicitly disabled', () => {
+    // GIVEN
+    const initialStackDescription = 'My Analytics stack';
+    const trackingTag = 'trackingTag';
+
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
+
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${trackingTag})`);
   });
 
-  // WHEN
-  const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+  test('tracked construct add as many tags in the description as tracked constructs in the stack', () => {
+    // GIVEN
+    const initialStackDescription = 'My super Analytics stack';
+    const construct1Tag = 'construct1';
+    const construct2Tag = 'construct2';
 
-  // THEN
-  expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${trackingTag})`);
-});
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
 
-test('tracked construct add as many tags in the description as tracked constructs in the stack', () => {
-  // GIVEN
-  const initialStackDescription = 'My super Analytics stack';
-  const construct1Tag = 'construct1';
-  const construct2Tag = 'construct2';
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct1', { trackingTag: construct1Tag });
+    new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct2', { trackingTag: construct2Tag });
 
-  const testApp = new App();
-  const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
-    description: initialStackDescription,
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${construct1Tag},${construct2Tag})`);
   });
 
-  // WHEN
-  const construct =new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct1', { trackingTag: construct1Tag });
-  new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct2', { trackingTag: construct2Tag });
+  test('tracked construct don\'t duplicate the same construct', () => {
+    // GIVEN
+    const initialStackDescription = 'My super Analytics stack';
+    const construct1Tag = 'construct1';
 
-  // THEN
-  expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${construct1Tag},${construct2Tag})`);
-});
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
 
-test('tracked construct don\'t add tracking code to description if explicitly disabled', () => {
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct1', { trackingTag: construct1Tag });
+    new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct2', { trackingTag: construct1Tag });
 
-  // GIVEN
-  const initialStackDescription = 'My Analytics stack';
-  const trackingTag = 'trackingcode';
-  const context: any = {};
-  context[ContextOptions.DISABLE_CONSTRUCTS_DEPLOYMENT_TRACKING] = true;
-  const testApp = new App({ context });
-  const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
-    description: initialStackDescription,
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${construct1Tag})`);
   });
 
-  // WHEN
-  new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+  test('tracked construct with similar but different names should be added', () => {
+    // GIVEN
+    const initialStackDescription = 'My super Analytics stack';
+    const construct1Tag = 'construct1';
+    const constructTag = 'construct';
 
-  // THEN
-  expect(exampleStack.templateOptions).toHaveProperty('description', initialStackDescription);
-});
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
 
-test('tracked construct add tracking code and tag without separator to description', () => {
-  // GIVEN
-  const initialStackDescription = 'My Analytics stack';
-  const trackingTag = 'my-construct,1';
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct1', { trackingTag: construct1Tag });
+    new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct2', { trackingTag: constructTag });
 
-  const testApp = new App();
-  const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
-    description: initialStackDescription,
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${construct1Tag},${constructTag})`);
   });
 
-  // WHEN
-  const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+  test('initial description already contains tracking code and version should update', ()=> {
+    // GIVEN
+    const initialStackDescription = `My Analytics stack (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:0.0.0)`;
+    const trackingTag = 'trackingTag';
 
-  // THEN
-  expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:my-construct_1)`);
-});
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
 
-class TestTrackedConstruct extends TrackedConstruct {
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
 
-  constructor(scope: Construct, id: string) {
-    const trackedConstructProps: TrackedConstructProps = {
-      trackingTag: 'TestTrackedConstruct',
-    };
-    super(scope, id, trackedConstructProps);
-    new Bucket(this, 'TestTrackedConstructWithBucket');
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `My Analytics stack (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:${trackingTag})`);
+  });
+
+  test('initial description already contains tracking code and version and tags should update', ()=> {
+    // GIVEN
+    const initialStackDescription = `My Analytics stack (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:0.0.0) (tag:existingTag)`;
+    const trackingTag = 'trackingTag';
+
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
+
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `My Analytics stack (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:existingTag,${trackingTag})`);
+  });
+
+  test('tracked construct don\'t add tracking code to description if explicitly disabled', () => {
+
+    // GIVEN
+    const initialStackDescription = 'My Analytics stack';
+    const trackingTag = 'trackingcode';
+    const context: any = {};
+    context[ContextOptions.DISABLE_CONSTRUCTS_DEPLOYMENT_TRACKING] = true;
+    const testApp = new App({ context });
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
+
+    // WHEN
+    new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', initialStackDescription);
+  });
+
+  test('tracked construct add tracking code and tag without separator to description', () => {
+    // GIVEN
+    const initialStackDescription = 'My Analytics stack';
+    const trackingTag = 'my-construct,1';
+
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
+
+    // WHEN
+    const construct = new TrackedConstruct(exampleStack, 'MyCoreAnalyticsConstruct', { trackingTag });
+
+    // THEN
+    expect(exampleStack.templateOptions).toHaveProperty('description', `${initialStackDescription} (${TrackedConstruct.ADSF_TRACKING_CODE}) (version:${construct.retrieveVersion()}) (tag:my-construct_1)`);
+  });
+
+  class TestTrackedConstruct extends TrackedConstruct {
+
+    constructor(scope: Construct, id: string) {
+      const trackedConstructProps: TrackedConstructProps = {
+        trackingTag: 'TestTrackedConstruct',
+      };
+      super(scope, id, trackedConstructProps);
+      new Bucket(this, 'TestTrackedConstructWithBucket');
+    }
   }
-}
 
-test('tracked construct add adsf:owned tag to the inner resources', () => {
-  // GIVEN
-  const initialStackDescription = 'My Analytics stack';
+  test('tracked construct add adsf:owned tag to the inner resources', () => {
+    // GIVEN
+    const initialStackDescription = 'My Analytics stack';
 
-  const testApp = new App();
-  const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
-    description: initialStackDescription,
+    const testApp = new App();
+    const exampleStack = new Stack(testApp, 'testTrackedConstruct', {
+      description: initialStackDescription,
+    });
+
+    // WHEN
+    new TestTrackedConstruct(exampleStack, 'MyTestTrackedConstruct');
+    const template = Template.fromStack(exampleStack);
+
+    // console.log(JSON.stringify(template));
+
+    // THEN
+    template.hasResource('AWS::S3::Bucket',
+      Match.objectLike({
+        Properties: {
+          Tags: [
+            {
+              Key: `${ADSF_AWS_TAG}:owned`,
+              Value: 'true',
+            },
+          ],
+        },
+      }),
+    );
   });
 
-  // WHEN
-  new TestTrackedConstruct(exampleStack, 'MyTestTrackedConstruct');
-  const template = Template.fromStack(exampleStack);
-
-  // console.log(JSON.stringify(template));
-
-  // THEN
-  template.hasResource('AWS::S3::Bucket',
-    Match.objectLike({
-      Properties: {
-        Tags: [
-          {
-            Key: `${ADSF_AWS_TAG}:owned`,
-            Value: 'true',
-          },
-        ],
-      },
-    }),
-  );
 });


### PR DESCRIPTION
When using the same construct twice, the tag was added twice. Also, when starting with a "formatted" description, update it, rather than concatenate it.

## Description of changes:

- Fix the double tags
- Update the description rather than concatenate

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
