### PR TITLE
fix: `crawlerTableLevelDepth` Property in Catalog 

### DIFF
--- a/framework/API.md
+++ b/framework/API.md
@@ -5378,7 +5378,7 @@ public readonly crawlerTableLevelDepth: number;
 ```
 
 - *Type:* number
-- *Default:* 3 if locationPrefix is not `/`, otherwise 2.
+- *Default:* calculated based on `locationPrefix`
 
 Directory depth where the table folders are located.
 
@@ -5486,7 +5486,7 @@ public readonly crawlerTableLevelDepth: number;
 ```
 
 - *Type:* number
-- *Default:* 3 if locationPrefix is not `/`, otherwise 2.
+- *Default:* calculated based on `locationPrefix`
 
 Directory depth where the table folders are located.
 

--- a/framework/API.md
+++ b/framework/API.md
@@ -5378,7 +5378,7 @@ public readonly crawlerTableLevelDepth: number;
 ```
 
 - *Type:* number
-- *Default:* 3. The default value follows the structure: `<bucket>/<databaseFolder>/<table1Folder>/`
+- *Default:* 3 if locationPrefix is not `/`, otherwise 2.
 
 Directory depth where the table folders are located.
 
@@ -5420,6 +5420,7 @@ const dataLakeCatalogProps: DataLakeCatalogProps = { ... }
 | <code><a href="#aws-dsf.DataLakeCatalogProps.property.autoCrawl">autoCrawl</a></code> | <code>boolean</code> | When enabled, this automatically creates a top level Glue Crawler that would run based on the defined schedule in the `autoCrawlSchedule` parameter. |
 | <code><a href="#aws-dsf.DataLakeCatalogProps.property.autoCrawlSchedule">autoCrawlSchedule</a></code> | <code>aws-cdk-lib.aws_glue.CfnCrawler.ScheduleProperty</code> | The schedule when the Crawler would run. |
 | <code><a href="#aws-dsf.DataLakeCatalogProps.property.crawlerLogEncryptionKey">crawlerLogEncryptionKey</a></code> | <code>aws-cdk-lib.aws_kms.Key</code> | Encryption key used for Crawler logs. |
+| <code><a href="#aws-dsf.DataLakeCatalogProps.property.crawlerTableLevelDepth">crawlerTableLevelDepth</a></code> | <code>number</code> | Directory depth where the table folders are located. |
 | <code><a href="#aws-dsf.DataLakeCatalogProps.property.databaseName">databaseName</a></code> | <code>string</code> | The name of the database in the Glue Data Catalog. |
 | <code><a href="#aws-dsf.DataLakeCatalogProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Policy to apply when the bucket is removed from this stack. |
 
@@ -5475,6 +5476,21 @@ public readonly crawlerLogEncryptionKey: Key;
 - *Default:* Create a new key if none is provided
 
 Encryption key used for Crawler logs.
+
+---
+
+##### `crawlerTableLevelDepth`<sup>Optional</sup> <a name="crawlerTableLevelDepth" id="aws-dsf.DataLakeCatalogProps.property.crawlerTableLevelDepth"></a>
+
+```typescript
+public readonly crawlerTableLevelDepth: number;
+```
+
+- *Type:* number
+- *Default:* 3 if locationPrefix is not `/`, otherwise 2.
+
+Directory depth where the table folders are located.
+
+This helps the crawler understand the layout of the folders in S3.
 
 ---
 

--- a/framework/src/governance/data-catalog-database.ts
+++ b/framework/src/governance/data-catalog-database.ts
@@ -90,7 +90,8 @@ export class DataCatalogDatabase extends TrackedConstruct {
     const currentStack = Stack.of(this);
 
     if (autoCrawl) {
-      const tableLevel = props.crawlerTableLevelDepth || 3;
+      const defaultTableLevelDepth = locationPrefix == '/' ? 2 : 3;
+      const tableLevel = props.crawlerTableLevelDepth || defaultTableLevelDepth;
       const crawlerRole = new Role(this, 'CrawlerRole', {
         assumedBy: new ServicePrincipal('glue.amazonaws.com'),
         inlinePolicies: {
@@ -292,7 +293,7 @@ export interface DataCatalogDatabaseProps {
 
   /**
    * Directory depth where the table folders are located. This helps the crawler understand the layout of the folders in S3.
-   * @default 3. The default value follows the structure: `<bucket>/<databaseFolder>/<table1Folder>/`
+   * @default 3 if locationPrefix is not `/`, otherwise 2.
    */
   readonly crawlerTableLevelDepth?: number;
 

--- a/framework/src/governance/data-catalog-database.ts
+++ b/framework/src/governance/data-catalog-database.ts
@@ -90,8 +90,7 @@ export class DataCatalogDatabase extends TrackedConstruct {
     const currentStack = Stack.of(this);
 
     if (autoCrawl) {
-      const defaultTableLevelDepth = locationPrefix == '/' ? 2 : 3;
-      const tableLevel = props.crawlerTableLevelDepth || defaultTableLevelDepth;
+      const tableLevel = props.crawlerTableLevelDepth || this.calculateDefaultTableLevelDepth(locationPrefix);
       const crawlerRole = new Role(this, 'CrawlerRole', {
         assumedBy: new ServicePrincipal('glue.amazonaws.com'),
         inlinePolicies: {
@@ -252,6 +251,20 @@ export class DataCatalogDatabase extends TrackedConstruct {
       ],
     }));
   }
+
+  private calculateDefaultTableLevelDepth(locationPrefix: string): number {
+    const baseCount = 2;
+
+    const locationTokens = locationPrefix.split('/');
+
+    let ctrValidToken = 0;
+
+    locationTokens.forEach((token) => {
+      ctrValidToken += (token) ? 1 : 0;
+    });
+
+    return ctrValidToken + baseCount;
+  }
 }
 
 /**
@@ -293,7 +306,7 @@ export interface DataCatalogDatabaseProps {
 
   /**
    * Directory depth where the table folders are located. This helps the crawler understand the layout of the folders in S3.
-   * @default 3 if locationPrefix is not `/`, otherwise 2.
+   * @default calculated based on `locationPrefix`
    */
   readonly crawlerTableLevelDepth?: number;
 

--- a/framework/src/governance/data-lake-catalog.ts
+++ b/framework/src/governance/data-lake-catalog.ts
@@ -57,34 +57,42 @@ export class DataLakeCatalog extends TrackedConstruct {
     const extractedBronzeBucketName = this.extractBucketName(props.dataLakeStorage.bronzeBucket);
     const extractedSilverBucketName = this.extractBucketName(props.dataLakeStorage.silverBucket);
     const extractedGoldBucketName = this.extractBucketName(props.dataLakeStorage.goldBucket);
+    const locationPrefix = props.databaseName || '/';
+
+    const defaultTableLevelDepth = locationPrefix == '/' ? 2 : 3;
+
+    const crawlerTableLevelDepth = props.crawlerTableLevelDepth || defaultTableLevelDepth;
 
     this.bronzeCatalogDatabase = new DataCatalogDatabase(this, 'BronzeCatalogDatabase', {
       locationBucket: props.dataLakeStorage.bronzeBucket,
-      locationPrefix: props.databaseName || '/',
+      locationPrefix,
       name: props.databaseName ? `${extractedBronzeBucketName}_${props.databaseName}` : extractedBronzeBucketName,
       autoCrawl: props.autoCrawl,
       autoCrawlSchedule: props.autoCrawlSchedule,
       crawlerLogEncryptionKey: this.crawlerLogEncryptionKey,
+      crawlerTableLevelDepth,
       removalPolicy,
     });
 
     this.silverCatalogDatabase = new DataCatalogDatabase(this, 'SilverCatalogDatabase', {
       locationBucket: props.dataLakeStorage.silverBucket,
-      locationPrefix: props.databaseName || '/',
+      locationPrefix,
       name: props.databaseName ? `${extractedSilverBucketName}_${props.databaseName}` : extractedSilverBucketName,
       autoCrawl: props.autoCrawl,
       autoCrawlSchedule: props.autoCrawlSchedule,
       crawlerLogEncryptionKey: this.crawlerLogEncryptionKey,
+      crawlerTableLevelDepth,
       removalPolicy,
     });
 
     this.goldCatalogDatabase = new DataCatalogDatabase(this, 'GoldCatalogDatabase', {
       locationBucket: props.dataLakeStorage.goldBucket,
-      locationPrefix: props.databaseName || '/',
+      locationPrefix,
       name: props.databaseName ? `${extractedGoldBucketName}_${props.databaseName}` : extractedGoldBucketName,
       autoCrawl: props.autoCrawl,
       autoCrawlSchedule: props.autoCrawlSchedule,
       crawlerLogEncryptionKey: this.crawlerLogEncryptionKey,
+      crawlerTableLevelDepth,
       removalPolicy,
     });
   }
@@ -133,6 +141,12 @@ export interface DataLakeCatalogProps {
    * @default Create a new key if none is provided
    */
   readonly crawlerLogEncryptionKey?: Key;
+
+  /**
+   * Directory depth where the table folders are located. This helps the crawler understand the layout of the folders in S3.
+   * @default 3 if locationPrefix is not `/`, otherwise 2.
+   */
+  readonly crawlerTableLevelDepth?: number;
 
   /**
    * Policy to apply when the bucket is removed from this stack.

--- a/framework/src/governance/data-lake-catalog.ts
+++ b/framework/src/governance/data-lake-catalog.ts
@@ -59,10 +59,6 @@ export class DataLakeCatalog extends TrackedConstruct {
     const extractedGoldBucketName = this.extractBucketName(props.dataLakeStorage.goldBucket);
     const locationPrefix = props.databaseName || '/';
 
-    const defaultTableLevelDepth = locationPrefix == '/' ? 2 : 3;
-
-    const crawlerTableLevelDepth = props.crawlerTableLevelDepth || defaultTableLevelDepth;
-
     this.bronzeCatalogDatabase = new DataCatalogDatabase(this, 'BronzeCatalogDatabase', {
       locationBucket: props.dataLakeStorage.bronzeBucket,
       locationPrefix,
@@ -70,7 +66,7 @@ export class DataLakeCatalog extends TrackedConstruct {
       autoCrawl: props.autoCrawl,
       autoCrawlSchedule: props.autoCrawlSchedule,
       crawlerLogEncryptionKey: this.crawlerLogEncryptionKey,
-      crawlerTableLevelDepth,
+      crawlerTableLevelDepth: props.crawlerTableLevelDepth,
       removalPolicy,
     });
 
@@ -81,7 +77,7 @@ export class DataLakeCatalog extends TrackedConstruct {
       autoCrawl: props.autoCrawl,
       autoCrawlSchedule: props.autoCrawlSchedule,
       crawlerLogEncryptionKey: this.crawlerLogEncryptionKey,
-      crawlerTableLevelDepth,
+      crawlerTableLevelDepth: props.crawlerTableLevelDepth,
       removalPolicy,
     });
 
@@ -92,7 +88,7 @@ export class DataLakeCatalog extends TrackedConstruct {
       autoCrawl: props.autoCrawl,
       autoCrawlSchedule: props.autoCrawlSchedule,
       crawlerLogEncryptionKey: this.crawlerLogEncryptionKey,
-      crawlerTableLevelDepth,
+      crawlerTableLevelDepth: props.crawlerTableLevelDepth,
       removalPolicy,
     });
   }
@@ -144,7 +140,7 @@ export interface DataLakeCatalogProps {
 
   /**
    * Directory depth where the table folders are located. This helps the crawler understand the layout of the folders in S3.
-   * @default 3 if locationPrefix is not `/`, otherwise 2.
+   * @default calculated based on `locationPrefix`
    */
   readonly crawlerTableLevelDepth?: number;
 

--- a/framework/test/e2e/spark-job.e2e.test.ts
+++ b/framework/test/e2e/spark-job.e2e.test.ts
@@ -20,12 +20,12 @@ const app = new cdk.App();
 const testStack = new TestStack('SparkJobTestStack', app);
 const { stack } = testStack;
 
+stack.node.setContext('@aws-data-solutions-framework/removeDataOnDestroy', true);
+
 // creation of the construct(s) under test
 const emrApp = new SparkEmrServerlessRuntime(stack, 'emrApp', {
   name: 'my-test-app',
 });
-
-stack.node.setContext('@aws-data-solutions-framework/removeDataOnDestroy', true);
 
 const myFileSystemPolicy = new PolicyDocument({
   statements: [new PolicyStatement({


### PR DESCRIPTION
## Description of changes:
- Added table level property in `DataLakeCatalog`
- Default value of table level would now depend on the value of `locationPrefix` property


* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)
