### PR TITLE
fix: e2e test for spark job deleting all resources

### DIFF
--- a/framework/test/e2e/spark-job.e2e.test.ts
+++ b/framework/test/e2e/spark-job.e2e.test.ts
@@ -25,6 +25,7 @@ stack.node.setContext('@aws-data-solutions-framework/removeDataOnDestroy', true)
 // creation of the construct(s) under test
 const emrApp = new SparkEmrServerlessRuntime(stack, 'emrApp', {
   name: 'my-test-app',
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
 });
 
 const myFileSystemPolicy = new PolicyDocument({
@@ -76,7 +77,7 @@ const jobSimple = new SparkEmrServerlessJob(stack, 'SparkJobSimple', {
   s3LogUri: 's3://log-bucker-dummy/monitoring-logs',
   sparkSubmitEntryPoint: 'local:///usr/lib/spark/examples/src/main/python/pi.py',
   sparkSubmitParameters: '--conf spark.executor.instances=2 --conf spark.executor.memory=2G --conf spark.driver.memory=2G --conf spark.executor.cores=4',
-
+  removalPolicy: cdk.RemovalPolicy.DESTROY,
 } as SparkEmrServerlessJobProps);
 
 new cdk.CfnOutput(stack, 'SparkJobStateMachine', {


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

The e2e test for the Spark Job construct is now deleting all resources because we leverage the `removalPolicy` parameter 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
