### PR TITLE
test: do not track e2e tests deployments

### DIFF
--- a/framework/test/e2e/test-stack.ts
+++ b/framework/test/e2e/test-stack.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AwsCdkCli, ICloudAssemblyDirectoryProducer, RequireApproval } from '@aws-cdk/cli-lib-alpha';
 import { App, Stack } from 'aws-cdk-lib';
+import { ContextOptions } from "../../src/utils";
 
 /**
  * Test stack that can be deployed to the selected environment.
@@ -32,6 +33,7 @@ class TestStack implements ICloudAssemblyDirectoryProducer {
   public constructor(stackName: string, app?: App, stack?: Stack) {
     this.app = app ?? new App();
     this.stack = stack ?? new Stack(this.app, stackName + '-' + randomUUID().substring(0, 8).toLowerCase());
+    this.stack.node.setContext(ContextOptions.DISABLE_CONSTRUCTS_DEPLOYMENT_TRACKING, true);
     this.#cli = AwsCdkCli.fromCloudAssemblyDirectoryProducer(this);
   }
 

--- a/framework/test/e2e/test-stack.ts
+++ b/framework/test/e2e/test-stack.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AwsCdkCli, ICloudAssemblyDirectoryProducer, RequireApproval } from '@aws-cdk/cli-lib-alpha';
 import { App, Stack } from 'aws-cdk-lib';
-import { ContextOptions } from "../../src/utils";
+import { ContextOptions } from '../../src/utils';
 
 /**
  * Test stack that can be deployed to the selected environment.


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Avoid tracking deployments made for e2e tests (using the context variable `DISABLE_CONSTRUCTS_DEPLOYMENT_TRACKING`).

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
