### PR TITLE
fix: Only create the KMS key when creating the VPC.

### DIFF
--- a/framework/src/processing/spark-runtime/emr-serverless/spark-emr-runtime-serverless.ts
+++ b/framework/src/processing/spark-runtime/emr-serverless/spark-emr-runtime-serverless.ts
@@ -184,6 +184,7 @@ export class SparkEmrServerlessRuntime extends TrackedConstruct {
     let emrNetworkConfiguration = undefined;
 
     if (!props.networkConfiguration) {
+      
       const logKmsKey: Key = new Key(scope, 'logKmsKey', {
         enableKeyRotation: true,
         alias: `flowlog-vpc-key-for-emr-application-${props.name}`,
@@ -191,7 +192,7 @@ export class SparkEmrServerlessRuntime extends TrackedConstruct {
         keyUsage: KeyUsage.ENCRYPT_DECRYPT,
         description: `Key used by the VPC created for EMR serverless application ${props.name}`,
       });
-      
+
       const networkConfiguration: NetworkConfiguration = vpcBootstrap(scope, '10.0.0.0/16', logKmsKey, props.removalPolicy, undefined, props.name);
 
       let privateSubnetIds: string [] = [];

--- a/framework/src/processing/spark-runtime/emr-serverless/spark-emr-runtime-serverless.ts
+++ b/framework/src/processing/spark-runtime/emr-serverless/spark-emr-runtime-serverless.ts
@@ -184,7 +184,7 @@ export class SparkEmrServerlessRuntime extends TrackedConstruct {
     let emrNetworkConfiguration = undefined;
 
     if (!props.networkConfiguration) {
-      
+
       const logKmsKey: Key = new Key(scope, 'logKmsKey', {
         enableKeyRotation: true,
         alias: `flowlog-vpc-key-for-emr-application-${props.name}`,

--- a/framework/src/processing/spark-runtime/emr-serverless/spark-emr-runtime-serverless.ts
+++ b/framework/src/processing/spark-runtime/emr-serverless/spark-emr-runtime-serverless.ts
@@ -175,24 +175,23 @@ export class SparkEmrServerlessRuntime extends TrackedConstruct {
 
     const removalPolicy = Context.revertRemovalPolicy(scope, props.removalPolicy);
 
-    const logKmsKey: Key = new Key(scope, 'logKmsKey', {
-      enableKeyRotation: true,
-      alias: `flowlog-vpc-key-for-emr-application-${props.name}`,
-      removalPolicy: removalPolicy,
-      keyUsage: KeyUsage.ENCRYPT_DECRYPT,
-      description: `Key used by the VPC created for EMR serverless application ${props.name}`,
-    });
-
     const releaseLabelSemver : string = emrReleaseLabel.split('-')[1];
 
     if (semver.lt(releaseLabelSemver, '6.9.0')) {
       throw new Error(`EMR Serverless supports release EMR 6.9 and above, provided release is ${emrReleaseLabel.toString()}`);
     }
 
-
     let emrNetworkConfiguration = undefined;
 
     if (!props.networkConfiguration) {
+      const logKmsKey: Key = new Key(scope, 'logKmsKey', {
+        enableKeyRotation: true,
+        alias: `flowlog-vpc-key-for-emr-application-${props.name}`,
+        removalPolicy: removalPolicy,
+        keyUsage: KeyUsage.ENCRYPT_DECRYPT,
+        description: `Key used by the VPC created for EMR serverless application ${props.name}`,
+      });
+      
       const networkConfiguration: NetworkConfiguration = vpcBootstrap(scope, '10.0.0.0/16', logKmsKey, props.removalPolicy, undefined, props.name);
 
       let privateSubnetIds: string [] = [];


### PR DESCRIPTION
**Issue #, if available:** n/a

## Description of changes:

If a VPC is passed to the serverless construct, it still creates a KMS key that ends up being unused. This change only creates the KMS key when creating the VPC.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/) (`fix: `, `feat: `, `docs: `, ...)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
